### PR TITLE
Update mount.py

### DIFF
--- a/changelogs/fragments/569_keep_mountpoint.yml
+++ b/changelogs/fragments/569_keep_mountpoint.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+- keep_mountpoint - added keep_mountpoint option with default value false. If set to true keep_mountpoint changes the behaviour of state: absent by keeping the mountpoint.
+
+# vim: ai sw=2 ts=2 et nu
+

--- a/changelogs/fragments/569_keep_mountpoint.yml
+++ b/changelogs/fragments/569_keep_mountpoint.yml
@@ -1,6 +1,3 @@
 ---
 minor_changes:
 - keep_mountpoint - added keep_mountpoint option with default value false. If set to true keep_mountpoint changes the behaviour of state: absent by keeping the mountpoint.
-
-# vim: ai sw=2 ts=2 et nu
-

--- a/changelogs/fragments/569_keep_mountpoint.yml
+++ b/changelogs/fragments/569_keep_mountpoint.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- keep_mountpoint - added keep_mountpoint option with default value false. If set to true keep_mountpoint changes the behaviour of state: absent by keeping the mountpoint.
+- keep_mountpoint - added keep_mountpoint option with default value false. If set to true keep_mountpoint changes the behaviour of state\: absent by keeping the mountpoint.

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -73,7 +73,7 @@ options:
         point will be created.
       - If V(unmounted), the device will be unmounted without changing I(fstab).
       - V(present) only specifies that the device is to be configured in
-        I(fstab) and does not trigger or require a mount. TODO check
+        I(fstab) and does not trigger or require a mount.
       - V(ephemeral) only specifies that the device is to be mounted, without changing
         I(fstab). If it is already mounted, a remount will be triggered.
         This will always return RV(ignore:changed=true). If the mount point O(path)

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -73,7 +73,7 @@ options:
         point will be created.
       - If V(unmounted), the device will be unmounted without changing I(fstab).
       - V(present) only specifies that the device is to be configured in
-        I(fstab) and does not trigger or require a mount.
+        I(fstab) and does not trigger or require a mount. 
       - V(ephemeral) only specifies that the device is to be mounted, without changing
         I(fstab). If it is already mounted, a remount will be triggered.
         This will always return RV(ignore:changed=true). If the mount point O(path)
@@ -87,7 +87,7 @@ options:
         real source. V(absent) does not unmount recursively, and the module will
         fail if multiple devices are mounted on the same mount point. Using
         V(absent) with a mount point that is not registered in the I(fstab) has
-        no effect, use V(unmounted) instead. You can set O(keep_mountpoint) to 
+        no effect, use V(unmounted) instead. You can set O(keep_mountpoint) to
         True to keep the mountpoint.
       - V(remounted) specifies that the device will be remounted for when you
         want to force a refresh on the mount itself (added in 2.9). This will
@@ -138,7 +138,7 @@ options:
     - Change the default behaviour of state=absent by keeping the mountpoint
     - With keep_mountpoint=true, state=absent is like unmounted plus the
       fstab update.
-    - Use it if you care about finding original mountpoint content without failing 
+    - Use it if you care about finding original mountpoint content without failing
       and want to remove the entry in fstab. If you have no entry to clean in
       fstab you can use state=unmounted
     type: bool

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -899,11 +899,6 @@ def main():
                     module.fail_json(
                         msg="Error unmounting %s: %s" % (name, msg))
 
-            if os.path.exists(name):
-                try:
-                    os.rmdir(name)
-                except (OSError, IOError) as e:
-                    module.fail_json(msg="Error rmdir %s: %s" % (name, to_native(e)))
     elif state == 'unmounted':
         if ismount(name) or is_bind_mounted(module, linux_mounts, name):
             if not module.check_mode:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -73,7 +73,7 @@ options:
         point will be created.
       - If V(unmounted), the device will be unmounted without changing I(fstab).
       - V(present) only specifies that the device is to be configured in
-        I(fstab) and does not trigger or require a mount. 
+        I(fstab) and does not trigger or require a mount.
       - V(ephemeral) only specifies that the device is to be mounted, without changing
         I(fstab). If it is already mounted, a remount will be triggered.
         This will always return RV(ignore:changed=true). If the mount point O(path)

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -186,7 +186,7 @@ EXAMPLES = r'''
     path: /tmp/mnt-pnt
     state: remounted
 
-# The following will fail on first run 
+# The following will fail on first run
 # if /home/mydir is not empty after unmounting,
 # though unmount and remove from fstab are successfull.
 # It will be successfull on subsequent runs (already unmounted).
@@ -194,7 +194,7 @@ EXAMPLES = r'''
   ansible.posix.mount:
     path: /home/mydir
     state: absent
-# The following will not fail on first run 
+# The following will not fail on first run
 # if /home/mydir is not empty after unmounting.
 # It will leave /home/mydir and its content (if any) after unmounting.
 - name: Unmount and remove from fstab, but keep /home/mydir

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -186,6 +186,23 @@ EXAMPLES = r'''
     path: /tmp/mnt-pnt
     state: remounted
 
+# The following will fail on first run 
+# if /home/mydir is not empty after unmounting,
+# though unmount and remove from fstab are successfull.
+# It will be successfull on subsequent runs (already unmounted).
+- name: Unmount and remove from fstab, then if unmount was necessary try to remove mountpoint /home/mydir
+  ansible.posix.mount:
+    path: /home/mydir
+    state: absent
+# The following will not fail on first run 
+# if /home/mydir is not empty after unmounting.
+# It will leave /home/mydir and its content (if any) after unmounting.
+- name: Unmount and remove from fstab, but keep /home/mydir
+  ansible.posix.mount:
+    path: /home/mydir
+    state: absent
+    keep_mountpoint: true
+
 # The following will not save changes to fstab, and only be temporary until
 # a reboot, or until calling "state: unmounted" followed by "state: mounted"
 # on the same "path"

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -789,3 +789,85 @@
       loop:
         - /tmp/myfs.img
         - /tmp/myfs
+
+- name: Block to test keep_mountpoint option
+  block:
+  - name: Create the mount point
+    ansible.builtin.file:
+      state: directory
+      path: '/tmp/myfs'
+      mode: '0755'
+
+  - name: Create empty file for FS aaa
+    community.general.filesize:
+      path: /tmp/myfs.img
+      size: 20M
+
+  - name: Format FS bbb
+    community.general.filesystem:
+      fstype: xfs
+      dev: /tmp/myfs.img
+
+  - name: Put data in the mount point before mounting
+    ansible.builtin.copy:
+      content: 'Testing
+        This is the data before mounting
+        '
+      dest: '/tmp/myfs/test_file'
+      mode: '0644'
+    register: file_before_info
+
+  - name: Mount with fstab
+    ansible.posix.mount:
+      path: '/tmp/myfs'
+      fstype: xfs
+      state: mounted
+      src: '/tmp/myfs.img'
+
+  - name: Check data disappears - stat data
+    ansible.builtin.stat:
+      path: '/tmp/myfs/test_file'
+    register: file_stat_after_mount
+  - name: Check data disappears - file does not exist
+    ansible.builtin.assert:
+      that:
+      - file_stat_after_mount['stat']['exists'] == false
+  - name: Put data in the mount point after mounting
+    ansible.builtin.copy:
+      content: 'Testing
+        This is the data updated after mounting
+        '
+      dest: '/tmp/myfs/test_file'
+      mode: '0644'
+    register: file_after_info
+  - name: Umount with keep_mountpoint
+    ansible.posix.mount:
+      path: '/tmp/myfs'
+      fstype: xfs
+      state: absent
+      keep_mountpoint: true
+  - name: Check original data reappears - stat data
+    ansible.builtin.stat:
+      path: '/tmp/myfs/test_file'
+    register: file_stat_after_umount
+  - name: Check original data reappears - compare checksums
+    ansible.builtin.assert:
+      that:
+      - file_stat_after_umount['stat']['checksum'] == file_before_info['checksum']
+  always:
+    - name: Remove the first test file
+      ansible.builtin.file:
+        path: /tmp/myfs/test_file
+        state: absent
+    - name: Unmount FS
+      ansible.posix.mount:
+        path: /tmp/myfs
+        state: absent
+    - name: Remove the test FS and the second test file
+      ansible.builtin.file:
+        path: '{{ item }}'
+        state: absent
+      loop:
+        - /tmp/myfs/test_file
+        - /tmp/myfs.img
+        - /tmp/myfs


### PR DESCRIPTION
In function main(), remove rmdir in case if state == 'absent'. Unmounting a file system should not lead to delete anything that is revealed after unmounting.  Also, it leads to an error if a non empty directory is present under the ex-mountpoint after umount : [Errno 39] Directory not empty So umount is successfull but the ansible run is failed. Of course, it is solved on second run.